### PR TITLE
Remove extra newline from PR description

### DIFF
--- a/backend/src/signprocessor/process.go
+++ b/backend/src/signprocessor/process.go
@@ -143,7 +143,7 @@ Signature file contents:
 		url,
 		description,
 		personalPage,
-		fmt.Sprintf("```\n%s\n```", contents),
+		fmt.Sprintf("```\n%s```", contents),
 	)
 
 	// Ensure we are forking from a clean state.


### PR DESCRIPTION
The code block in the PR descriptions created by the bot seem to have an extra newline at the end. See https://github.com/neveragaindottech/neveragaindottech.github.io/pull/1835.