### PR TITLE
Escape Twitter bios

### DIFF
--- a/backend/src/signprocessor/process.go
+++ b/backend/src/signprocessor/process.go
@@ -141,7 +141,7 @@ Signature file contents:
 		created, followers, following, tweets, egg,
 		displayName,
 		url,
-		description,
+		fmt.Sprintf("`%s`", description),
 		personalPage,
 		fmt.Sprintf("```\n%s```", contents),
 	)


### PR DESCRIPTION
Since Twitter bios can contain usernames in the same format as GitHub usernames in GFMD, not escaping them means that the auto-opened PRs might end up spamming real users by accident.

For example, this happened with me and my fiancée, `@ticky`, whose username is in my Twitter bio. She received an email notification when https://github.com/neveragaindottech/neveragaindottech.github.io/pull/1961 was created after I used signbot to create a PR via Twitter, since her Twitter username is in my Twitter bio, and her GitHub username is the same.